### PR TITLE
SigningKeyResolver의 private 생성자 제거

### DIFF
--- a/src/main/java/cwchoiit/springsecurity/jwt/SigningKeyResolver.java
+++ b/src/main/java/cwchoiit/springsecurity/jwt/SigningKeyResolver.java
@@ -8,10 +8,6 @@ import java.security.Key;
 
 public class SigningKeyResolver extends SigningKeyResolverAdapter {
 
-    private SigningKeyResolver() {
-        throw new UnsupportedOperationException("This class cannot be instantiated");
-    }
-
     public static SigningKeyResolver instance = new SigningKeyResolver();
 
     @Override


### PR DESCRIPTION
이 클래스의 인스턴스를 생성하지 못하게 하면, JWT 인증을 할 수 없음.